### PR TITLE
Stack size methods have been moved to process template

### DIFF
--- a/core/os_kernel.cpp
+++ b/core/os_kernel.cpp
@@ -118,8 +118,7 @@ TBaseProcess::TBaseProcess( stack_item_t * StackPoolEnd
                       #if scmRTOS_DEBUG_ENABLE == 1
                             , WaitingFor(0)
                             , StackPool(aStackPool)
-                            , StackSize(StackPoolEnd - aStackPool)
-                      #endif 
+                      #endif
                       #if scmRTOS_PROCESS_RESTART_ENABLE == 1
                             , WaitingProcessMap(0)
                       #endif
@@ -150,10 +149,8 @@ TBaseProcess::TBaseProcess( stack_item_t * Stack
                       #if scmRTOS_DEBUG_ENABLE == 1
                             , WaitingFor(0)
                             , StackPool(aStackPool)
-                            , StackSize(Stack - aStackPool)
                             , RStackPool(aRStackPool)
-                            , RStackSize(RStack - aRStackPool)
-                      #endif 
+                      #endif
                       #if scmRTOS_PROCESS_RESTART_ENABLE == 1
                             , WaitingProcessMap(0)
                       #endif

--- a/core/os_kernel.h
+++ b/core/os_kernel.h
@@ -249,12 +249,10 @@ namespace OS
     #if scmRTOS_DEBUG_ENABLE == 1
         INLINE TService * waiting_for() const { return WaitingFor; }
     public:
-               size_t     stack_size() const { return StackSize; }
-               size_t     stack_slack() const; 
+               size_t     stack_slack() const;
         #if SEPARATE_RETURN_STACK == 1
-               size_t     rstack_size() const { return RStackSize; }
                size_t     rstack_slack() const;
-        #endif               
+        #endif
     #endif // scmRTOS_DEBUG_ENABLE
 
     #if scmRTOS_PROCESS_RESTART_ENABLE == 1
@@ -275,13 +273,11 @@ namespace OS
     #if scmRTOS_DEBUG_ENABLE == 1
         TService           * volatile WaitingFor;
         const stack_item_t * const StackPool;
-        const size_t       StackSize; // as number of stack_item_t items
         #if SEPARATE_RETURN_STACK == 1
             const stack_item_t * const RStackPool;
-            const size_t               RStackSize;
         #endif
     #endif // scmRTOS_DEBUG_ENABLE
-    
+
     #if scmRTOS_PROCESS_RESTART_ENABLE == 1
         volatile TProcessMap * WaitingProcessMap;
     #endif
@@ -315,6 +311,10 @@ namespace OS
         #if scmRTOS_PROCESS_RESTART_ENABLE == 1
             INLINE void terminate();
         #endif
+
+    #if scmRTOS_DEBUG_ENABLE == 1
+            size_t stack_size() const { return stk_size; }
+    #endif // scmRTOS_DEBUG_ENABLE
 
         private:
             stack_item_t Stack[stk_size/sizeof(stack_item_t)];
@@ -366,6 +366,11 @@ namespace OS
         #if scmRTOS_PROCESS_RESTART_ENABLE == 1
             INLINE void terminate();
         #endif
+
+    #if scmRTOS_DEBUG_ENABLE == 1
+            size_t stack_size() const { return stk_size; }
+            size_t rstack_size() const { return rstk_size; }
+    #endif // scmRTOS_DEBUG_ENABLE
 
         private:
             stack_item_t Stack [stk_size/sizeof(stack_item_t)];


### PR DESCRIPTION
The way to initialize of the stack size members prevents calculation the constructor body in compile time (IAR for STM8). Moving methods that return process stack size to "process" template allows to reduce memory consumption.
