### PR TITLE
cortex port: fix switch context call

### DIFF
--- a/port/cortex/mx-gcc/os_target.h
+++ b/port/cortex/mx-gcc/os_target.h
@@ -281,7 +281,8 @@ namespace OS
 #if scmRTOS_CONTEXT_SWITCH_SCHEME == 1
 
 // 0xE000ED04 - Interrupt Control State Register
-INLINE void raise_context_switch() { *((volatile uint32_t*)0xE000ED04) |= 0x10000000; }
+// set PENDSVSET bit
+INLINE void raise_context_switch() { *((volatile uint32_t*)0xE000ED04) = 0x10000000; }
 
 #define ENABLE_NESTED_INTERRUPTS()
 


### PR DESCRIPTION
для вызова PendSV достаточно установить один бит, не трогая остальные

https://electronix.ru/forum/index.php?app=forums&module=forums&controller=topic&id=140053&do=findComment&comment=1577204